### PR TITLE
Use executable location as working directory

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,12 +56,7 @@ var infoTable *tview.Table
 var debugText *tview.TextView
 var tree *tview.TreeView
 
-var (
-	_ = determineWorkingDirectory()
-	configFile = "config.json"
-)
-
-func determineWorkingDirectory() string {
+func setWorkingDirectory() {
 	// Get the absolute path this executable is located in.
 	executablePath, err := os.Executable()
 	if err != nil {
@@ -70,13 +65,13 @@ func determineWorkingDirectory() string {
 	}
 	// Set the working directory to the path the executable is located in.
 	os.Chdir(filepath.Dir(executablePath))
-	return ""
 }
 
 func main() {
 	//start UI
 	app = tview.NewApplication()
-	file, err := ioutil.ReadFile(configFile)
+	setWorkingDirectory()
+	file, err := ioutil.ReadFile("config.json")
 	con.CheckUpdate = true
 	con.Lang = "en"
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
@@ -55,10 +56,27 @@ var infoTable *tview.Table
 var debugText *tview.TextView
 var tree *tview.TreeView
 
+var (
+	_ = determineWorkingDirectory()
+	configFile = "config.json"
+)
+
+func determineWorkingDirectory() string {
+	// Get the absolute path this executable is located in.
+	executablePath, err := os.Executable()
+	if err != nil {
+		debugPrint("Error: Couldn't determine working directory:")
+		debugPrint(err.Error())
+	}
+	// Set the working directory to the path the executable is located in.
+	os.Chdir(filepath.Dir(executablePath))
+	return ""
+}
+
 func main() {
 	//start UI
 	app = tview.NewApplication()
-	file, err := ioutil.ReadFile("config.json")
+	file, err := ioutil.ReadFile(configFile)
 	con.CheckUpdate = true
 	con.Lang = "en"
 	if err != nil {


### PR DESCRIPTION
Ensures config.json is found when F1viewer is called from elsewhere