### PR TITLE
feat: first class VLC support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,16 +1,13 @@
 project_name: f1viewer
 builds:
-  - 
-    goos:
+  - goos:
       - linux
       - windows
-      - darwin
     goarch:
       - amd64
       - 386
 archives:
-  -
-    replacements:
+  - replacements:
       amd64: 64-bit
       386: 32-bit
       darwin: macOS
@@ -24,8 +21,7 @@ snapshot:
 changelog:
   skip: true
 nfpms:
-  -
-    description: TUI client for F1TV
+  - description: TUI client for F1TV
     license: GPL-3.0-only
     homepage: https://github.com/SoMuchForSubtlety/f1viewer/
     maintainer: SoMuchForSubtlety <s0muchfrsubtlety@gmail.com>
@@ -34,10 +30,10 @@ nfpms:
     formats:
       - deb
       - rpm
-    dependencies:
-      - mpv
     recommends:
       - xclip
+      - mpv
+      - vlc
 # does not work due to cgo not being supported by goreleaser
 # brews:
 #   -

--- a/main.go
+++ b/main.go
@@ -55,6 +55,8 @@ type viewerSession struct {
 	app        *tview.Application
 	textWindow *tview.TextView
 	tree       *tview.TreeView
+
+	commands map[string]bool
 }
 
 var (
@@ -84,6 +86,7 @@ func main() {
 		os.Exit(0)
 	}()
 
+	go session.checkCommands("vlc", "mpv")
 	go session.checkLive()
 	go session.CheckUpdate()
 
@@ -114,6 +117,8 @@ func main() {
 func newSession() (*viewerSession, *os.File, error) {
 	var err error
 	session := &viewerSession{}
+
+	session.commands = make(map[string]bool)
 
 	session.cfg, err = loadConfig()
 	if err != nil {

--- a/util.go
+++ b/util.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os/exec"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -13,6 +14,27 @@ import (
 	"github.com/gdamore/tcell"
 	"github.com/rivo/tview"
 )
+
+func (session *viewerSession) checkCommands(commands ...string) {
+	var found int
+	for _, cmd := range commands {
+		_, err := exec.LookPath(cmd)
+		session.commands[cmd] = err == nil
+		if err == nil {
+			found++
+		} else {
+			session.logInfo("could not find ", cmd)
+		}
+	}
+	if found == 0 {
+		session.logError("Both MPV and VLC are unavailable!")
+	}
+}
+
+func (session *viewerSession) commandAvailable(command string) bool {
+	available, ok := session.commands[command]
+	return ok && available
+}
 
 // takes year/race ID and returns full year and race nuber as strings
 func getYearAndRace(input string) (string, string, error) {

--- a/util_test.go
+++ b/util_test.go
@@ -11,6 +11,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestAvailableCommands(t *testing.T) {
+	t.Parallel()
+	_, s := newTestApp(t, 20, 5)
+	s.commands["test1"] = true
+	s.commands["test2"] = false
+
+	assert.True(t, s.commandAvailable("test1"))
+	assert.False(t, s.commandAvailable("test2"))
+	assert.False(t, s.commandAvailable("test3"))
+}
+
 func TestSanitizeFileName(t *testing.T) {
 	t.Parallel()
 	title := `file name: "with" <illegal> \/characters|`
@@ -209,5 +220,5 @@ func newTestApp(t *testing.T, x, y int) (tcell.SimulationScreen, viewerSession) 
 
 	app.SetRoot(flex, true)
 
-	return simScreen, viewerSession{tree: tree, app: app, textWindow: text}
+	return simScreen, viewerSession{tree: tree, app: app, textWindow: text, commands: make(map[string]bool)}
 }


### PR DESCRIPTION
- unify command node creation
- add VLC to default playback options
- check for MPV and VLC availability on startup
- only show nodes if the underlying command is available