### PR TITLE
Added support for borderless MPV stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/SoMuchForSubtlety/f1viewer)](https://goreportcard.com/report/github.com/SoMuchForSubtlety/f1viewer)
 ![](https://github.com/SoMuchForSubtlety/f1viewer/workflows/Test/badge.svg)
+# Changes from original Version by somuchforsubtlety
+
+* Added support for borderless play of stream with MPV without having to fiddle with the config
 
 # f1viewer
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/SoMuchForSubtlety/f1viewer)](https://goreportcard.com/report/github.com/SoMuchForSubtlety/f1viewer)
 ![](https://github.com/SoMuchForSubtlety/f1viewer/workflows/Test/badge.svg)
-# Changes from original Version by somuchforsubtlety
-
-* Added support for borderless play of stream with MPV without having to fiddle with the config
 
 # f1viewer
 

--- a/cmd.go
+++ b/cmd.go
@@ -51,6 +51,10 @@ func (session *viewerSession) loadCommands() {
 			Command: []string{"mpv", "$url", "--alang=" + session.cfg.Lang, "--start=0", "--quiet", "--title=$title"},
 		},
 		{
+			Title:   "Play with MPV without border",
+			Command: []string{"mpv", "$url", "--border=no", "--alang=" + session.cfg.Lang, "--start=0", "--quiet", "--title=$title"},
+		},
+		{
 			Title:   "Play with VLC",
 			Command: []string{"vlc", "$url", "--meta-title=$title"},
 		},


### PR DESCRIPTION
This adds the functionality for a borderless MPV stream by default, removing the need to fiddle with the hard to use config file for less experienced users.
Adds custom node titled "Play with MPV without border"