### PR TITLE
showing config file output

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,8 +66,7 @@ var (
 )
 
 func main() {
-	var showVersion bool
-	var showConfig bool
+	var showVersion, showConfig bool
 	flag.BoolVar(&showVersion, "v", showVersion, "show version information")
 	flag.BoolVar(&showVersion, "version", showVersion, "show version information")
 	flag.BoolVar(&showConfig, "c", showConfig, "show config information")

--- a/main.go
+++ b/main.go
@@ -67,11 +67,18 @@ var (
 
 func main() {
 	var showVersion bool
+	var showConfig bool
 	flag.BoolVar(&showVersion, "v", showVersion, "show version information")
 	flag.BoolVar(&showVersion, "version", showVersion, "show version information")
+	flag.BoolVar(&showConfig, "c", showConfig, "show config information")
+	flag.BoolVar(&showConfig, "config", showConfig, "show config information")
 	flag.Parse()
 	if showVersion {
 		fmt.Println(buildVersion())
+		return
+	}
+	if showConfig {
+		fmt.Println(buildConfigPath())
 		return
 	}
 
@@ -301,6 +308,15 @@ func buildVersion() string {
 	}
 	if date != "" {
 		result += fmt.Sprintf("\nBuilt:       %s", date)
+	}
+	return result
+}
+
+func buildConfigPath() string {
+	path, err := getConfigPath()
+	result := fmt.Sprintf("Config file:  %s", path)
+	if err != nil {
+		result += fmt.Sprintf("\nThere was an error reading config file:  %s", err)
 	}
 	return result
 }


### PR DESCRIPTION
fixes #121

would be nice to also output the log path, but `getLogPath()` needs a `config` and that needs a session and I was wondering if that's a bit much 😊

for now, it does what it should, though I was thinking about refactoring the code into a function called something like `showFlagsOutput()` or something...