### PR TITLE
Enable ARM builds for Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ goreleaser.exe
 dist/
 *.exe~
 .vscode/
+.idea/
 downloads/
 *.txt
 F1viewer

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,6 +10,8 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm
+      - arm64
   - id: mac
     goos:
       - darwin


### PR DESCRIPTION
This compiles the program for both 32-bit and 64-bit ARM processors, and fixes #133. Since the request was for 32-bit builds, and my impression is that 64-bit ARM is, or will be, more prevalent I figured building for the 64-bit processors couldn't hurt.