### PR TITLE
Bump go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/SoMuchForSubtlety/f1viewer
 
-go 1.14
+go 1.16
 
 replace github.com/rivo/tview => github.com/SoMuchForSubtlety/tview v0.0.0-20210213192247-c4de038979df
 


### PR DESCRIPTION
Looking through the code I noticed that you bumped the Go version used in CI (5742b0dbc757fdc9722c98ad5318f6d6a51fe651), but not the one specified in the go.mod file. Fairly inconsequential change, but I figured you'd be interested in keeping them synchronized.