### PR TITLE
Working on fixing #167 403 during auth flow

### DIFF
--- a/pkg/f1tv/v1/auth.go
+++ b/pkg/f1tv/v1/auth.go
@@ -68,15 +68,6 @@ func authenticate(username, password string) (authResponse, error) {
 }
 
 func (f *F1TV) setPlan() error {
-	//if len(token.PlanUrls) == 0 {
-	//	return nil
-	//}
-
-	//plan, err := GetPlan(token.PlanUrls[0])
-	//if err != nil {
-	//	return err
-	//}
-
 	f.plan = SubscriptionPlan("pro")
 
 	return nil


### PR DESCRIPTION
This evening I dug into the 403 issue that's been reported 3 times.  It's an error generated by CloudFront, so something has changed at F1TV.  The URL F1Viewer uses for the getToken response no longer accepts POSTs.

I traced through what my browser was doing, and it never did the token swap that F1Viewer was set up to do (and that was causing auth to fail).  It looks like it just uses the subscription token for everything.  So as an initial stab at solving the issue, I took out the token swap & used the subscription token as the ascendon token.  That worked.

Obviously this works for me, but I have a few concerns I haven't been able to track down:

* I'm curious if the F1TV app does this token swap, but I did not put in the effort to trace its HTTP requests.
* I don't have a way to determine whether this is a Pro or Access subscription (you can see I've hardcoded it to "pro" in the meantime).  I looked through all the requests made by my browser and found none that contained the plain string "pro" in the response.
* I am curious if F1TV have removed this token swap altogether on their side.  It's also possible they've moved the URL.  I'm not sure how to find out which.

I'd love to have some input on how you figured out the token swap was happening in the first place and how I might go about tracing through that flow again.  Thanks!