### PR TITLE
Use more readable race titles

### DIFF
--- a/pkg/f1tv/v2/api.go
+++ b/pkg/f1tv/v2/api.go
@@ -146,6 +146,9 @@ func (f *F1TV) GetPageContent(id PageID) ([]TopContainer, []RemoteContent, error
 				}
 				title := contentContainer.Metadata.Label
 				if title == "" {
+					title = contentContainer.Metadata.TitleBrief
+				}
+				if title == "" {
 					title = contentContainer.Metadata.EmfAttributes.GlobalTitle
 				}
 				if title == "" {


### PR DESCRIPTION
This change prioritizes the brief title of a GP (e.g. "Styrian Grand Prix 2021") over the global title (e.g. "FORMULA 1 BWT GROSSER PREIS DER STEIRMARK 2021") in the GP selection UI. This essentially reverts the titles to what they were before 2.1.0, and should make it more readable.

Related: #175 